### PR TITLE
Rename base class for generators for better semantics

### DIFF
--- a/src/StructId.Analyzer/BaseGenerator.cs
+++ b/src/StructId.Analyzer/BaseGenerator.cs
@@ -20,7 +20,7 @@ public enum ReferenceCheck
     ValueIsType,
 }
 
-public abstract class TemplateGenerator(string referenceType, string stringTemplate, string typeTemplate, ReferenceCheck referenceCheck = ReferenceCheck.ValueIsType) : IIncrementalGenerator
+public abstract class BaseGenerator(string referenceType, string stringTemplate, string typeTemplate, ReferenceCheck referenceCheck = ReferenceCheck.ValueIsType) : IIncrementalGenerator
 {
     protected record struct TemplateArgs(string TargetNamespace, INamedTypeSymbol StructId, INamedTypeSymbol ValueType, INamedTypeSymbol ReferenceType, INamedTypeSymbol StringType);
 

--- a/src/StructId.Analyzer/ComparableGenerator.cs
+++ b/src/StructId.Analyzer/ComparableGenerator.cs
@@ -3,7 +3,7 @@
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class ComparableGenerator() : TemplateGenerator(
+public class ComparableGenerator() : BaseGenerator(
     "System.IComparable`1",
     ThisAssembly.Resources.Templates.Comparable.Text,
     ThisAssembly.Resources.Templates.Comparable.Text,

--- a/src/StructId.Analyzer/ConstructorGenerator.cs
+++ b/src/StructId.Analyzer/ConstructorGenerator.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class ConstructorGenerator() : TemplateGenerator(
+public class ConstructorGenerator() : BaseGenerator(
     "System.Object",
     ThisAssembly.Resources.Templates.Constructor.Text,
     ThisAssembly.Resources.Templates.ConstructorT.Text,

--- a/src/StructId.Analyzer/ConversionGenerator.cs
+++ b/src/StructId.Analyzer/ConversionGenerator.cs
@@ -3,7 +3,7 @@
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class ConversionGenerator() : TemplateGenerator(
+public class ConversionGenerator() : BaseGenerator(
     "System.Object",
     ThisAssembly.Resources.Templates.Conversion.Text,
     ThisAssembly.Resources.Templates.ConversionT.Text,

--- a/src/StructId.Analyzer/DapperGenerator.cs
+++ b/src/StructId.Analyzer/DapperGenerator.cs
@@ -7,7 +7,7 @@ using Scriban;
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class DapperGenerator() : TemplateGenerator(
+public class DapperGenerator() : BaseGenerator(
     "Dapper.SqlMapper+TypeHandler`1", "", "", ReferenceCheck.TypeExists)
 {
     static readonly Template template = Template.Parse(ThisAssembly.Resources.DapperExtensions.Text);

--- a/src/StructId.Analyzer/EntityFrameworkGenerator.cs
+++ b/src/StructId.Analyzer/EntityFrameworkGenerator.cs
@@ -7,7 +7,7 @@ using Scriban;
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class EntityFrameworkGenerator() : TemplateGenerator(
+public class EntityFrameworkGenerator() : BaseGenerator(
     "Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter`2",
     ThisAssembly.Resources.Templates.EntityFramework.Text,
     ThisAssembly.Resources.Templates.EntityFramework.Text,

--- a/src/StructId.Analyzer/NewableGenerator.cs
+++ b/src/StructId.Analyzer/NewableGenerator.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class NewableGenerator() : TemplateGenerator(
+public class NewableGenerator() : BaseGenerator(
     "System.Object",
     ThisAssembly.Resources.Templates.Newable.Text,
     ThisAssembly.Resources.Templates.NewableT.Text,

--- a/src/StructId.Analyzer/NewtonsoftJsonGenerator.cs
+++ b/src/StructId.Analyzer/NewtonsoftJsonGenerator.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class NewtonsoftJsonGenerator() : TemplateGenerator(
+public class NewtonsoftJsonGenerator() : BaseGenerator(
     "Newtonsoft.Json.JsonConverter`1",
     ThisAssembly.Resources.Templates.NewtonsoftJsonConverter.Text,
     ThisAssembly.Resources.Templates.NewtonsoftJsonConverterT.Text,

--- a/src/StructId.Analyzer/ParsableGenerator.cs
+++ b/src/StructId.Analyzer/ParsableGenerator.cs
@@ -3,7 +3,7 @@
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class ParsableGenerator() : TemplateGenerator(
+public class ParsableGenerator() : BaseGenerator(
     "System.IParsable`1",
     ThisAssembly.Resources.Templates.Parsable.Text,
     ThisAssembly.Resources.Templates.ParsableT.Text);

--- a/src/StructId.Analyzer/SystemTextJsonGenerator.cs
+++ b/src/StructId.Analyzer/SystemTextJsonGenerator.cs
@@ -3,7 +3,7 @@
 namespace StructId;
 
 [Generator(LanguageNames.CSharp)]
-public class SystemTextJsonGenerator() : TemplateGenerator(
+public class SystemTextJsonGenerator() : BaseGenerator(
     "System.IParsable`1",
     ThisAssembly.Resources.Templates.JsonConverter.Text,
     ThisAssembly.Resources.Templates.JsonConverterT.Text);

--- a/src/StructId/Templates/TSelf.cs
+++ b/src/StructId/Templates/TSelf.cs
@@ -23,7 +23,7 @@ partial record struct TId : ISpanParsable<TId>, IComparable<TId>
     public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, [MaybeNullWhen(false)] out TId result)
         => TryParse(s.ToString(), provider, out result);
 
-    public int CompareTo(TId other) => other.CompareTo(this);
+    public int CompareTo(TId other) => throw new NotImplementedException();
 }
 
 readonly partial record struct Self : IStructId


### PR DESCRIPTION
The base generator provides built-in transformation from embedded templates, but the true "templated generators" will be the ones users can customize by providing their own templates.

This will make naming confusing down the road. So rename now before we embark on that.