### PR TITLE
Showcase generic templates applying to all struct ids

### DIFF
--- a/src/StructId.Analyzer/AnalysisExtensions.cs
+++ b/src/StructId.Analyzer/AnalysisExtensions.cs
@@ -40,7 +40,8 @@ public static class AnalysisExtensions
             if (iface.Is(baseTypeOrInterface))
                 return true;
 
-        if (@this.BaseType?.Name.Equals("object", StringComparison.OrdinalIgnoreCase) == true)
+        if (@this.BaseType?.Name.Equals("object", StringComparison.OrdinalIgnoreCase) == true &&
+            @this.BaseType?.Equals(baseTypeOrInterface, SymbolEqualityComparer.Default) != true)
             return false;
 
         return Is(@this.BaseType, baseTypeOrInterface);

--- a/src/StructId.FunctionalTests/ObjectTemplate.cs
+++ b/src/StructId.FunctionalTests/ObjectTemplate.cs
@@ -1,0 +1,7 @@
+﻿using StructId;
+
+[TStructId]
+file partial record struct ObjectTemplate(object Value)
+{
+    // applies to any struct id, whether struct or string
+}

--- a/src/StructId.FunctionalTests/StructTemplate.cs
+++ b/src/StructId.FunctionalTests/StructTemplate.cs
@@ -1,0 +1,7 @@
+﻿using StructId;
+
+[TStructId]
+file partial record struct StructTemplate(ValueType Value)
+{
+    // applies to any ValueType-based struct id
+}


### PR DESCRIPTION
A generic template can be applied to all struct-based ids by providing a ValueType primary constructor. To make it apply to both structs and string-based ids, use `object` as the primary constructor value.