### PR TITLE
Fix improper type names in sample templates

### DIFF
--- a/src/StructId.FunctionalTests/ObjectTemplate.cs
+++ b/src/StructId.FunctionalTests/ObjectTemplate.cs
@@ -2,7 +2,7 @@
 using StructId.Functional;
 
 [TStructId]
-file partial record struct ObjectTemplate(object Value)
+file partial record struct TSelf(object Value)
 {
     // applies to any struct id, whether struct or string
 }

--- a/src/StructId.FunctionalTests/StructTemplate.cs
+++ b/src/StructId.FunctionalTests/StructTemplate.cs
@@ -2,7 +2,7 @@
 using StructId.Functional;
 
 [TStructId]
-file partial record struct StructTemplate(ValueType Value)
+file partial record struct TSelf(ValueType Value)
 {
     // applies to any ValueType-based struct id
 }


### PR DESCRIPTION
TSelf/TId are not required (pending an analyzer to enforce this).