### PR TITLE
Create analyzer and codefix for templates

### DIFF
--- a/src/StructId.Analyzer/Diagnostics.cs
+++ b/src/StructId.Analyzer/Diagnostics.cs
@@ -6,8 +6,8 @@ public static class Diagnostics
 {
     public static DiagnosticDescriptor MustBeRecordStruct { get; } = new(
         "SID001",
-        "Struct ids must be partial readonly record structs",
-        "Change '{0}' to a partial readonly record struct as required for types used as struct ids.",
+        "Struct Ids must be partial readonly record structs",
+        "'{0}' must be a partial readonly record struct to be a struct ids.",
         "Build",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
@@ -15,10 +15,37 @@ public static class Diagnostics
 
     public static DiagnosticDescriptor MustHaveValueConstructor { get; } = new(
         "SID002",
-        "Struct id custom constructor must provide a single Value parameter",
+        "Struct Id custom constructor must provide a single Value parameter",
         "Custom constructor for '{0}' must have a Value parameter",
         "Build",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         helpLinkUri: $"{ThisAssembly.Project.RepositoryUrl}/blob/{ThisAssembly.Project.RepositoryBranch}/docs/SID002.md");
+
+    public static DiagnosticDescriptor TemplateMustBeFileRecordStruct { get; } = new(
+        "SID003",
+        "Struct Id templates must be file-local partial record structs",
+        "'{0}' must be a file-local partial record struct to be used as a template.",
+        "Build",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: $"{ThisAssembly.Project.RepositoryUrl}/blob/{ThisAssembly.Project.RepositoryBranch}/docs/SID003.md");
+
+    public static DiagnosticDescriptor TemplateConstructorValueConstructor { get; } = new(
+        "SID004",
+        "Struct Id template constructor must provide a single Value parameter",
+        "Custom template constructor must have a single Value parameter, if present",
+        "Build",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: $"{ThisAssembly.Project.RepositoryUrl}/blob/{ThisAssembly.Project.RepositoryBranch}/docs/SID004.md");
+
+    public static DiagnosticDescriptor TemplateDeclarationNotTSelf { get; } = new(
+        "SID005",
+        "Struct Id template declaration must use the reserved name 'TSelf'",
+        "'{0}' must be named 'TSelf' to be used as a template.",
+        "Build",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: $"{ThisAssembly.Project.RepositoryUrl}/blob/{ThisAssembly.Project.RepositoryBranch}/docs/SID005.md");
 }

--- a/src/StructId.Analyzer/TemplateAnalyzer.cs
+++ b/src/StructId.Analyzer/TemplateAnalyzer.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static StructId.Diagnostics;
+
+namespace StructId;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class TemplateAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(TemplateMustBeFileRecordStruct, TemplateConstructorValueConstructor, TemplateDeclarationNotTSelf);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        if (!Debugger.IsAttached)
+            context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ClassDeclaration);
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.StructDeclaration);
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.RecordDeclaration);
+        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.RecordStructDeclaration);
+    }
+
+    static void Analyze(SyntaxNodeAnalysisContext context)
+    {
+        var ns = context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.GetStructIdNamespace();
+
+        if (context.Node is not TypeDeclarationSyntax typeDeclaration ||
+            !typeDeclaration.AttributeLists.Any(list => list.Attributes.Any(attr => attr.IsStructIdTemplate())))
+            return;
+
+        var symbol = context.SemanticModel.GetDeclaredSymbol(typeDeclaration);
+        if (symbol is null)
+            return;
+
+        if (!symbol.IsFileLocal || !symbol.IsPartial() || !typeDeclaration.IsKind(SyntaxKind.RecordStructDeclaration))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(TemplateMustBeFileRecordStruct, typeDeclaration.Identifier.GetLocation(), symbol.Name));
+        }
+
+        // If there are parameters, it must be only one, and be named Value
+        if (typeDeclaration.ParameterList is { } parameters)
+        {
+
+            if (typeDeclaration.ParameterList.Parameters.Count != 1)
+                context.ReportDiagnostic(Diagnostic.Create(TemplateConstructorValueConstructor, typeDeclaration.ParameterList.GetLocation(), symbol.Name));
+            else if (typeDeclaration.ParameterList.Parameters[0].Identifier.Text != "Value")
+                context.ReportDiagnostic(Diagnostic.Create(TemplateConstructorValueConstructor, typeDeclaration.ParameterList.Parameters[0].Identifier.GetLocation(), symbol.Name));
+        }
+
+        if (typeDeclaration.Identifier.Text != "TSelf")
+            context.ReportDiagnostic(Diagnostic.Create(TemplateDeclarationNotTSelf, typeDeclaration.Identifier.GetLocation(), symbol.Name));
+    }
+}

--- a/src/StructId.CodeFix/RenameCtorCodeFix.cs
+++ b/src/StructId.CodeFix/RenameCtorCodeFix.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static StructId.Diagnostics;
 
 namespace StructId;
 
@@ -14,7 +15,8 @@ namespace StructId;
 [ExportCodeFixProvider(LanguageNames.CSharp)]
 public class RenameCtorCodeFix : CodeFixProvider
 {
-    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(Diagnostics.MustHaveValueConstructor.Id);
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+        MustHaveValueConstructor.Id, TemplateConstructorValueConstructor.Id);
 
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -35,7 +37,7 @@ public class RenameCtorCodeFix : CodeFixProvider
 
     public class RenameAction(Document document, SyntaxNode root, ParameterSyntax parameter) : CodeAction
     {
-        public override string Title => "Rename to 'Value' as required for struct ids";
+        public override string Title => "Rename to 'Value'";
         public override string EquivalenceKey => Title;
 
         protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)

--- a/src/StructId.CodeFix/TemplateCodeFix.cs
+++ b/src/StructId.CodeFix/TemplateCodeFix.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static StructId.Diagnostics;
+
+namespace StructId;
+
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+public class TemplateCodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(
+        TemplateMustBeFileRecordStruct.Id, TemplateDeclarationNotTSelf.Id);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root == null)
+            return;
+
+        var declaration = root.FindNode(context.Span).FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (declaration == null)
+            return;
+
+        context.RegisterCodeFix(
+            new FixerAction(context.Document, root, declaration),
+            context.Diagnostics);
+    }
+
+    public class FixerAction(Document document, SyntaxNode root, TypeDeclarationSyntax original) : CodeAction
+    {
+        public override string Title => "Change to file-local partial record struct";
+        public override string EquivalenceKey => Title;
+
+        protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+        {
+            var declaration = original;
+            var modifiers = declaration.Modifiers;
+
+            if (!modifiers.Any(SyntaxKind.FileKeyword))
+                modifiers = modifiers.Insert(0, Token(SyntaxKind.FileKeyword));
+
+            if (!modifiers.Any(SyntaxKind.PartialKeyword))
+                modifiers = modifiers.Insert(1, Token(SyntaxKind.PartialKeyword));
+
+            // Remove accessibility modifiers which are replaced by 'file' visibility
+            if (modifiers.FirstOrDefault(x => x.IsKind(SyntaxKind.PublicKeyword)) is { } @public)
+                modifiers = modifiers.Remove(@public);
+            if (modifiers.FirstOrDefault(x => x.IsKind(SyntaxKind.InternalKeyword)) is { } @internal)
+                modifiers = modifiers.Remove(@internal);
+            if (modifiers.FirstOrDefault(x => x.IsKind(SyntaxKind.PrivateKeyword)) is { } @private)
+                modifiers = modifiers.Remove(@private);
+
+            if (declaration.Identifier.Text != "TSelf")
+                declaration = declaration.WithIdentifier(Identifier("TSelf"));
+
+            if (!declaration.IsKind(SyntaxKind.RecordStructDeclaration))
+            {
+                declaration = RecordDeclaration(
+                    SyntaxKind.RecordStructDeclaration,
+                    declaration.AttributeLists,
+                    modifiers,
+                    Token(SyntaxKind.RecordKeyword),
+                    Token(SyntaxKind.StructKeyword),
+                    declaration.Identifier,
+                    declaration.TypeParameterList,
+                    declaration.ParameterList,
+                    declaration.BaseList,
+                    declaration.ConstraintClauses,
+                    declaration.OpenBraceToken,
+                    declaration.Members,
+                    declaration.CloseBraceToken,
+                    declaration.SemicolonToken);
+            }
+            else if (modifiers != declaration.Modifiers)
+            {
+                declaration = declaration.WithModifiers(modifiers);
+            }
+
+            return Task.FromResult(document.WithSyntaxRoot(root.ReplaceNode(original, declaration)));
+        }
+    }
+}

--- a/src/StructId.Tests/CodeTemplateTests.cs
+++ b/src/StructId.Tests/CodeTemplateTests.cs
@@ -101,4 +101,39 @@ public class CodeTemplateTests(ITestOutputHelper output)
             """).NormalizeWhitespace().ToFullString().Trim().ReplaceLineEndings(),
             applied.ReplaceLineEndings());
     }
+
+    [Fact]
+    public void RemovesFileLocalTypes()
+    {
+        var template =
+            """
+            using StructId;
+            
+            [TStructId]
+            file partial record struct TSelf
+            {
+              // From template
+            }
+
+            file record TSome;
+            file class TAnother;
+            file record struct TYetAnother;
+            """;
+
+        var applied = CodeTemplate.Apply(template, "Foo", "string", normalizeWhitespace: true);
+
+        output.WriteLine(applied);
+
+        Assert.Equal(
+            CodeTemplate.Parse(
+            """
+            using StructId;
+
+            partial record struct Foo
+            {
+              // From template
+            }            
+            """).NormalizeWhitespace().ToFullString().Trim().ReplaceLineEndings(),
+            applied.ReplaceLineEndings());
+    }
 }

--- a/src/StructId.Tests/TemplateAnalyzerTests.cs
+++ b/src/StructId.Tests/TemplateAnalyzerTests.cs
@@ -1,0 +1,177 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using StructId;
+using Xunit.Sdk;
+using Test = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<StructId.TemplateAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<StructId.TemplateAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace StructId;
+
+public class TemplateAnalyzerTests
+{
+    [Fact]
+    public async Task RecordStructNoTemplate()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                public record struct TSelf(int Value);
+                """,
+        }.WithAnalyzerDefaults();
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ClassNoTemplate()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                public class TSelf(int Value);
+                """,
+        }.WithAnalyzerDefaults();
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ClassRecordNoTemplate()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                public record TSelf(int Value);
+                """,
+        }.WithAnalyzerDefaults();
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TemplateRecordStructNotPartial()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+
+                [TStructId]
+                file record struct {|#0:TSelf|};
+                """,
+        }.WithAnalyzerDefaults();
+
+        test.ExpectedDiagnostics.Add(Verifier.Diagnostic(Diagnostics.TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TemplateRecordStructNotFile()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+
+                [TStructId]
+                partial record struct {|#0:TSelf|};
+                """,
+        }.WithAnalyzerDefaults();
+
+        test.ExpectedDiagnostics.Add(Verifier.Diagnostic(Diagnostics.TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TemplateRecordClassNotStruct()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+
+                [TStructId]
+                file partial record {|#0:TSelf|};
+                """,
+        }.WithAnalyzerDefaults();
+
+        test.ExpectedDiagnostics.Add(Verifier.Diagnostic(Diagnostics.TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TemplateStructNotRecord()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+
+                [TStructId]
+                file partial struct {|#0:TSelf|};
+                """,
+        }.WithAnalyzerDefaults();
+
+        test.ExpectedDiagnostics.Add(Verifier.Diagnostic(Diagnostics.TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TemplateWithNonValueConstructor()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct TSelf(int {|#0:value|});
+                """,
+        }.WithAnalyzerDefaults();
+
+        test.ExpectedDiagnostics.Add(Verifier.Diagnostic(Diagnostics.TemplateConstructorValueConstructor).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task TemplateNotTSelf()
+    {
+        var test = new Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+
+                [TStructId]
+                file partial record struct {|#0:Foo|};
+                """,
+        }.WithAnalyzerDefaults();
+
+        test.ExpectedDiagnostics.Add(Verifier.Diagnostic(Diagnostics.TemplateDeclarationNotTSelf).WithLocation(0).WithArguments("Foo"));
+
+        await test.RunAsync();
+    }
+}

--- a/src/StructId.Tests/TemplateCodeFixTests.cs
+++ b/src/StructId.Tests/TemplateCodeFixTests.cs
@@ -1,0 +1,177 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using static StructId.Diagnostics;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<StructId.TemplateAnalyzer, Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace StructId;
+
+public class TemplateCodeFixTests
+{
+    [Fact]
+    public async Task AddPartialKeyword()
+    {
+        var test = new CSharpCodeFixTest<TemplateAnalyzer, TemplateCodeFix, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+                
+                [TStructId]
+                file record struct {|#0:TSelf|};
+                """,
+            FixedCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct TSelf;
+                """,
+        }.WithCodeFixDefaults();
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task RemovePublicKeyword()
+    {
+        var test = new CSharpCodeFixTest<TemplateAnalyzer, TemplateCodeFix, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+                
+                [TStructId]
+                public partial record struct {|#0:TSelf|};
+                """,
+            FixedCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct TSelf;
+                """,
+        }.WithCodeFixDefaults();
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task RemoveInternalKeyword()
+    {
+        var test = new CSharpCodeFixTest<TemplateAnalyzer, TemplateCodeFix, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+                
+                [TStructId]
+                internal partial record struct {|#0:TSelf|};
+                """,
+            FixedCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct TSelf;
+                """,
+        }.WithCodeFixDefaults();
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ChangeStructToRecordStruct()
+    {
+        var test = new CSharpCodeFixTest<TemplateAnalyzer, TemplateCodeFix, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial struct {|#0:TSelf|};
+                """,
+            FixedCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct TSelf;
+                """,
+        }.WithCodeFixDefaults();
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task ChangeClassToRecordStruct()
+    {
+        var test = new CSharpCodeFixTest<TemplateAnalyzer, TemplateCodeFix, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file class {|#0:TSelf|};
+                """,
+            FixedCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct TSelf;
+                """,
+        }.WithCodeFixDefaults();
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(TemplateMustBeFileRecordStruct).WithLocation(0).WithArguments("TSelf"));
+
+        await test.RunAsync();
+    }
+
+    [Fact]
+    public async Task RenameTSelf()
+    {
+        var test = new CSharpCodeFixTest<TemplateAnalyzer, TemplateCodeFix, DefaultVerifier>
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            TestCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct {|#0:Foo|};
+                """,
+            FixedCode =
+                """
+                using StructId;
+            
+                [TStructId]
+                file partial record struct TSelf;
+                """,
+        }.WithCodeFixDefaults();
+
+        test.ExpectedDiagnostics.Add(new DiagnosticResult(TemplateDeclarationNotTSelf).WithLocation(0).WithArguments("Foo"));
+
+        await test.RunAsync();
+    }
+}


### PR DESCRIPTION
Templates need to adhere to some minimal rules:
1. File-local visibility and partial
2. Record struct themselves (since they will be partial of another record struct)
3. Optional primary ctor with Value parameter to allow template code to operate on the underlying value of the struct id as needed.

We now enforce these rules via an analyzer and provide a codefix to help authoring.