### PR TITLE
Showcase extensibility by leveraging Ulid

### DIFF
--- a/src/StructId.Analyzer/ConstructorGenerator.cs
+++ b/src/StructId.Analyzer/ConstructorGenerator.cs
@@ -15,5 +15,5 @@ public class ConstructorGenerator() : BaseGenerator(
     // we cannot switch this to the simpler compiled templates, which don't have conditional logic
     protected override IncrementalValuesProvider<TemplateArgs> OnInitialize(IncrementalGeneratorInitializationContext context, IncrementalValuesProvider<TemplateArgs> source)
         => base.OnInitialize(context, source.Where(x
-            => x.StructId.DeclaringSyntaxReferences.Select(r => r.GetSyntax()).OfType<TypeDeclarationSyntax>().All(s => s.ParameterList == null)));
+            => x.TSelf.DeclaringSyntaxReferences.Select(r => r.GetSyntax()).OfType<TypeDeclarationSyntax>().All(s => s.ParameterList == null)));
 }

--- a/src/StructId.Analyzer/DapperExtensions.sbn
+++ b/src/StructId.Analyzer/DapperExtensions.sbn
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Data;
 using Dapper;
+using static Dapper.SqlMapper;
 
 namespace {{ Namespace }};
 
@@ -21,13 +22,41 @@ public static partial class DapperExtensions
     {
         {{~ for id in Ids ~}}
         if (!SqlMapper.HasTypeHandler(typeof({{ id.TSelf }})))
-            SqlMapper.AddTypeHandler(new DapperTypeHandler{{ id.TId }}<{{ id.TSelf }}>());        
+            SqlMapper.AddTypeHandler(new DapperTypeHandler{{ id.TId }}<{{ id.TSelf }}>());
 
-        {{~ end ~}}        
+        {{~ end ~}}
+        {{~ for id in CustomIds ~}}
+        if (!SqlMapper.HasTypeHandler(typeof({{ id.TSelf }})))
+            SqlMapper.AddTypeHandler(new DapperTypeHandler<{{ id.TSelf }}, {{ id.TId }}, {{ id.THandler }}>());
+
+        {{~ end ~}}
+        {{~ for handler in CustomHandlers ~}}
+        if (!SqlMapper.HasTypeHandler(typeof({{ handler }})))
+            SqlMapper.AddTypeHandler(new {{ handler }}());
+
+        {{~ end ~}}
+
         return connection;
     }
 
-    partial class DapperTypeHandlerInt64<TSelf> : SqlMapper.TypeHandler<TSelf>
+    partial class DapperTypeHandler<TSelf, TId, THandler> : TypeHandler<TSelf>
+        where TSelf : IStructId<TId>, INewable<TSelf, TId>
+        where THandler : TypeHandler<TId>, new()
+        where TId : struct
+    {
+        readonly THandler handler = new();
+
+        public override TSelf? Parse(object value) => TSelf.New(handler.Parse(value));
+        public override void SetValue(IDbDataParameter parameter, TSelf? value)
+        {
+            if (value?.Value is { } id)
+                handler.SetValue(parameter, value?.Value ?? default);
+            else
+                parameter.Value = DBNull.Value;
+        }
+    }
+
+    partial class DapperTypeHandlerInt64<TSelf> : TypeHandler<TSelf>
         where TSelf : IStructId<long>, INewable<TSelf, long>
     {
         public override void SetValue(IDbDataParameter parameter, TSelf? value)
@@ -55,7 +84,7 @@ public static partial class DapperExtensions
         }
     }
 
-    partial class DapperTypeHandlerInt32<TSelf> : SqlMapper.TypeHandler<TSelf>
+    partial class DapperTypeHandlerInt32<TSelf> : TypeHandler<TSelf>
         where TSelf : IStructId<int>, INewable<TSelf, int>
     {
         public override void SetValue(IDbDataParameter parameter, TSelf? value)
@@ -82,7 +111,7 @@ public static partial class DapperExtensions
         }
     }
 
-    partial class DapperTypeHandlerGuid<TSelf> : SqlMapper.TypeHandler<TSelf>
+    partial class DapperTypeHandlerGuid<TSelf> : TypeHandler<TSelf>
         where TSelf : IStructId<Guid>, INewable<TSelf, Guid>
     {
         public override void SetValue(IDbDataParameter parameter, TSelf? value)
@@ -107,7 +136,7 @@ public static partial class DapperExtensions
         }
     }
 
-    partial class DapperTypeHandlerString<TSelf> : SqlMapper.TypeHandler<TSelf>
+    partial class DapperTypeHandlerString<TSelf> : TypeHandler<TSelf>
         where TSelf : IStructId, INewable<TSelf>
     {
         public override void SetValue(IDbDataParameter parameter, TSelf? value)

--- a/src/StructId.Analyzer/DapperGenerator.cs
+++ b/src/StructId.Analyzer/DapperGenerator.cs
@@ -14,7 +14,7 @@ public class DapperGenerator() : BaseGenerator(
 
     protected override IncrementalValuesProvider<TemplateArgs> OnInitialize(IncrementalGeneratorInitializationContext context, IncrementalValuesProvider<TemplateArgs> source)
     {
-        var supported = source.Where(x => x.ValueType.ToFullName() switch
+        var supported = source.Where(x => x.TId.ToFullName() switch
         {
             "System.String" => true,
             "System.Guid" => true,
@@ -26,29 +26,60 @@ public class DapperGenerator() : BaseGenerator(
             _ => false
         });
 
-        context.RegisterSourceOutput(supported.Collect(), GenerateHandlers);
+        var handlers = context.CompilationProvider
+            .SelectMany((x, _) => x.Assembly.GetAllTypes().OfType<INamedTypeSymbol>())
+            .Combine(context.CompilationProvider.Select((x, _) => x.GetTypeByMetadataName("Dapper.SqlMapper+TypeHandler`1")))
+            .Where(x => x.Left != null && x.Right != null && x.Left.Is(x.Right))
+            .Select((x, _) => x.Left)
+            .Collect();
+
+        var custom = source
+            .Combine(handlers)
+            .Select((x, _) =>
+            {
+                (TemplateArgs args, ImmutableArray<INamedTypeSymbol> handlers) = x;
+
+                var handlerType = args.ReferenceType.Construct(args.TId);
+                var handler = handlers.FirstOrDefault(x => x.Is(handlerType, false));
+
+                return args with { ReferenceType = handler! };
+            })
+            .Where(x => x.ReferenceType != null);
+
+        context.RegisterSourceOutput(supported.Collect().Combine(custom.Collect()), GenerateHandlers);
 
         // Turn off codegen in the base template.
         return source.Where(x => false);
     }
 
-    void GenerateHandlers(SourceProductionContext context, ImmutableArray<TemplateArgs> args)
+    void GenerateHandlers(SourceProductionContext context, (ImmutableArray<TemplateArgs> ids, ImmutableArray<TemplateArgs> custom) source)
     {
-        if (args.Length == 0)
+        var (ids, custom) = source;
+        if (ids.Length == 0 && custom.Length == 0)
             return;
 
+        var known = ids.Concat(custom).First().KnownTypes;
+        var customHandlers = custom.Select(x => x.ReferenceType.ToFullName()).Distinct().ToArray();
+
         var model = new SelectorModel(
-            args.First().StructIdNamespace,
-            args.Select(x => new StructIdModel(x.StructId.ToFullName(), x.ValueType.Name)));
+            known.StructIdNamespace,
+            ids.Select(x => new StructIdModel(x.TSelf.ToFullName(), x.TId.Name)),
+            custom.Select(x => new StructIdCustomModel(x.TSelf.ToFullName(), x.TId.Name, x.ReferenceType.ToFullName())),
+            customHandlers);
 
         var output = template.Render(model, member => member.Name);
         context.AddSource($"DapperExtensions.cs", output);
     }
 
     public static string Render(string @namespace, string tself, string tid)
-        => template.Render(new SelectorModel(@namespace, [new StructIdModel(tself, tid)]), member => member.Name);
+        => template.Render(new SelectorModel(@namespace, [new(tself, tid)], [], []), member => member.Name);
+
+    public static string RenderCustom(string @namespace, string tself, string tid, string thandler)
+        => template.Render(new SelectorModel(@namespace, [], [new(tself, tid, thandler)], [thandler]), member => member.Name);
 
     record StructIdModel(string TSelf, string TId);
 
-    record SelectorModel(string Namespace, IEnumerable<StructIdModel> Ids);
+    record StructIdCustomModel(string TSelf, string TId, string THandler);
+
+    record SelectorModel(string Namespace, IEnumerable<StructIdModel> Ids, IEnumerable<StructIdCustomModel> CustomIds, IEnumerable<string> CustomHandlers);
 }

--- a/src/StructId.Analyzer/EntityFrameworkGenerator.cs
+++ b/src/StructId.Analyzer/EntityFrameworkGenerator.cs
@@ -27,7 +27,7 @@ public class EntityFrameworkGenerator() : BaseGenerator(
         if (args.Length == 0)
             return;
 
-        var model = new SelectorModel(args.Select(x => new StructIdModel(x.StructId.ToFullName(), x.ValueType.ToFullName())));
+        var model = new SelectorModel(args.Select(x => new StructIdModel(x.TSelf.ToFullName(), x.TId.ToFullName())));
         var output = template.Render(model, member => member.Name);
         context.AddSource($"ValueConverterSelector.cs", output);
     }

--- a/src/StructId.Analyzer/KnownTypes.cs
+++ b/src/StructId.Analyzer/KnownTypes.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace StructId;
+
+/// <summary>
+/// Provides access to some common types and properties used in the compilation.
+/// </summary>
+/// <param name="Compilation">The compilation used to resolve the known types.</param>
+/// <param name="StructIdNamespace">The namespace for StructId types.</param>
+public record KnownTypes(Compilation Compilation, string StructIdNamespace)
+{
+    /// <summary>
+    /// System.String
+    /// </summary>
+    public INamedTypeSymbol String { get; } = Compilation.GetTypeByMetadataName("System.String")!;
+    /// <summary>
+    /// StructId.IStructId
+    /// </summary>
+    public INamedTypeSymbol? IStructId { get; } = Compilation.GetTypeByMetadataName($"{StructIdNamespace}.IStructId");
+    /// <summary>
+    /// StructId.IStructId{T}
+    /// </summary>
+    public INamedTypeSymbol? IStructIdT { get; } = Compilation.GetTypeByMetadataName($"{StructIdNamespace}.IStructId`1");
+    /// <summary>
+    /// StructId.TStructIdAttribute
+    /// </summary>
+    public INamedTypeSymbol? TStructId { get; } = Compilation.GetTypeByMetadataName($"{StructIdNamespace}.TStructIdAttribute");
+}

--- a/src/StructId.Analyzer/TemplatedGenerator.cs
+++ b/src/StructId.Analyzer/TemplatedGenerator.cs
@@ -12,31 +12,6 @@ namespace StructId;
 public partial class TemplatedGenerator : IIncrementalGenerator
 {
     /// <summary>
-    /// Provides access to some common types and properties used in the compilation.
-    /// </summary>
-    /// <param name="Compilation">The compilation used to resolve the known types.</param>
-    /// <param name="StructIdNamespace">The namespace for StructId types.</param>
-    record KnownTypes(Compilation Compilation, string StructIdNamespace)
-    {
-        /// <summary>
-        /// System.String
-        /// </summary>
-        public INamedTypeSymbol String { get; } = Compilation.GetTypeByMetadataName("System.String")!;
-        /// <summary>
-        /// StructId.IStructId
-        /// </summary>
-        public INamedTypeSymbol? IStructId { get; } = Compilation.GetTypeByMetadataName($"{StructIdNamespace}.IStructId");
-        /// <summary>
-        /// StructId.IStructId{T}
-        /// </summary>
-        public INamedTypeSymbol? IStructIdT { get; } = Compilation.GetTypeByMetadataName($"{StructIdNamespace}.IStructId`1");
-        /// <summary>
-        /// StructId.TStructIdAttribute
-        /// </summary>
-        public INamedTypeSymbol? TStructId { get; } = Compilation.GetTypeByMetadataName($"{StructIdNamespace}.TStructIdAttribute");
-    }
-
-    /// <summary>
     /// Represents a template for struct ids.
     /// </summary>
     /// <param name="StructId">The struct id type, either IStructId or IStructId{T}.</param>

--- a/src/StructId.FunctionalTests/DapperTests.cs
+++ b/src/StructId.FunctionalTests/DapperTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Data.Sqlite;
+
+namespace StructId.Functional;
+
+// showcases Ulid integration
+public readonly partial record struct UlidId : IStructId<Ulid>;
+
+public record UlidProduct(UlidId Id, string Name);
+
+public class StringUlidHandler : Dapper.SqlMapper.TypeHandler<Ulid>
+{
+    public override Ulid Parse(object value)
+    {
+        return Ulid.Parse((string)value);
+    }
+
+    public override void SetValue(IDbDataParameter parameter, Ulid value)
+    {
+        parameter.DbType = DbType.StringFixedLength;
+        parameter.Size = 26;
+        parameter.Value = value.ToString();
+    }
+}
+
+// showcases alternative serialization
+//public class BinaryUlidHandler : TypeHandler<Ulid>
+//{
+//    public override Ulid Parse(object value)
+//    {
+//        return new Ulid((byte[])value);
+//    }
+
+//    public override void SetValue(IDbDataParameter parameter, Ulid value)
+//    {
+//        parameter.DbType = DbType.Binary;
+//        parameter.Size = 16;
+//        parameter.Value = value.ToByteArray();
+//    }
+//}
+
+public class DapperTests
+{
+    [Fact]
+    public void Dapper()
+    {
+        using var connection = new SqliteConnection("Data Source=dapper.db")
+            .UseStructId();
+
+        connection.Open();
+
+        // Seed data
+        var productId = Guid.NewGuid();
+        var product = new Product(new ProductId(productId), "Product");
+
+        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", new Product(ProductId.New(), "Product1"));
+        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", product);
+        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", new Product(ProductId.New(), "Product2"));
+
+        var product2 = connection.QueryFirst<Product>("SELECT * FROM Products WHERE Id = @Id", new { Id = productId });
+        Assert.Equal(product, product2);
+    }
+
+    [Fact]
+    public void DapperUlid()
+    {
+        using var connection = new SqliteConnection("Data Source=dapper.db")
+            .UseStructId();
+
+        connection.Open();
+
+        // Seed data
+        var productId = Ulid.NewUlid();
+        var product = new UlidProduct(new UlidId(productId), "Product");
+
+        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", new UlidProduct(UlidId.New(), "Product1"));
+        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", product);
+        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", new UlidProduct(UlidId.New(), "Product2"));
+
+        var product2 = connection.QueryFirst<UlidProduct>("SELECT * FROM Products WHERE Id = @Id", new { Id = productId });
+        Assert.Equal(product, product2);
+    }
+
+}

--- a/src/StructId.FunctionalTests/Functional.cs
+++ b/src/StructId.FunctionalTests/Functional.cs
@@ -107,26 +107,6 @@ public class FunctionalTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public void Dapper()
-    {
-        using var connection = new SqliteConnection("Data Source=dapper.db")
-            .UseStructId();
-
-        connection.Open();
-
-        // Seed data
-        var productId = Guid.NewGuid();
-        var product = new Product(new ProductId(productId), "Product");
-
-        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", new Product(ProductId.New(), "Product1"));
-        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", product);
-        connection.Execute("INSERT INTO Products (Id, Name) VALUES (@Id, @Name)", new Product(ProductId.New(), "Product2"));
-
-        var product2 = connection.QueryFirst<Product>("SELECT * FROM Products WHERE Id = @Id", new { Id = productId });
-        Assert.Equal(product, product2);
-    }
-
-    [Fact]
     public void CustomTemplate()
     {
         var id = ProductId.New();

--- a/src/StructId.FunctionalTests/NewUlid.cs
+++ b/src/StructId.FunctionalTests/NewUlid.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StructId.Functional;
+
+[TStructId]
+file partial record struct TSelf(Ulid Value)
+{
+    public static TSelf New() => new(Ulid.NewUlid());
+}
+
+file partial record struct TSelf : INewable<TSelf, Ulid>
+{
+    public static TSelf New(Ulid value) => throw new NotImplementedException();
+}

--- a/src/StructId.FunctionalTests/StructId.FunctionalTests.csproj
+++ b/src/StructId.FunctionalTests/StructId.FunctionalTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageReference Include="Ulid" Version="1.3.4" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/StructId.Tests/StructId.Tests.csproj
+++ b/src/StructId.Tests/StructId.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Scriban" Version="5.12.0" GeneratePathProperty="true" />
     <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Ulid" Version="1.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add (non-official) support for Ulid by excercising extensibility points, including custom template for New() for Ulid-based IDs, as well as (new) extensibility in Dapper generation to plug in your own primitive types into our extension method too.