### PR TITLE
Rename TId > TValue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,15 +24,15 @@ Unlike other such libraries for .NET, StructId introduces several unique feature
 1. Leverages newest language and runtime features for cleaner and more efficient code, 
    such as:
    1. `IParsable<T>`/`ISpanParsable<T>` for parsing from strings.
-   1. Static interface members, for consistent `TSelf.New(TId value)` factory 
-      method and proper type constraint (via a provided `INewable<TSelf, TId>` interface).
+   1. Static interface members, for consistent `TSelf.New(TValue value)` factory 
+      method and proper type constraint (via a provided `INewable<TSelf, TValue>` interface).
    1. File-scoped C# templates for unparalelled authoring and extensibility experience.
 
 ## Usage
 
 After installing the [StructId package](https://nuget.org/packages/StructId), the project 
 (with a direct reference to the `StructId` package) will contain the main interfaces 
-`IStruct` (for string-typed IDs) and `IStructId<TId>`. 
+`IStruct` (for string-typed IDs) and `IStructId<TValue>`. 
 
 > NOTE: the package only needs to be installed in the top-level project in your solution, 
 > since analyzers/generators will [automatically propagate to referencing projects]((https://github.com/dotnet/sdk/issues/1212)).
@@ -44,7 +44,7 @@ publish one that uses struct ids).
 The default target namespace for the included types will match the `RootNamespace` of the 
 project, but can be customized by setting the `StructIdNamespace` property.
 
-You can simply declare a new ID type by implementing `IStructId<TId>`:
+You can simply declare a new ID type by implementing `IStructId<TValue>`:
 
 ```csharp
 public readonly partial record struct UserId : IStructId<Guid>;

--- a/src/StructId.Analyzer/BaseGenerator.cs
+++ b/src/StructId.Analyzer/BaseGenerator.cs
@@ -22,7 +22,7 @@ public abstract class BaseGenerator(string referenceType, string stringTemplate,
     SyntaxNode? stringSyntax;
     SyntaxNode? typedSyntax;
 
-    protected record struct TemplateArgs(INamedTypeSymbol TSelf, INamedTypeSymbol TId, INamedTypeSymbol ReferenceType, KnownTypes KnownTypes);
+    protected record struct TemplateArgs(INamedTypeSymbol TSelf, INamedTypeSymbol TValue, INamedTypeSymbol ReferenceType, KnownTypes KnownTypes);
 
     public virtual void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -60,7 +60,7 @@ public abstract class BaseGenerator(string referenceType, string stringTemplate,
             });
 
         if (referenceCheck == ReferenceCheck.ValueIsType)
-            combined = combined.Where(x => x.TId.Is(x.ReferenceType));
+            combined = combined.Where(x => x.TValue.Is(x.ReferenceType));
 
         combined = OnInitialize(context, combined);
 
@@ -73,7 +73,7 @@ public abstract class BaseGenerator(string referenceType, string stringTemplate,
         => AddFromTemplate(context, args, $"{args.TSelf.ToFileName()}.cs", SelectTemplate(args));
 
     protected virtual SyntaxNode SelectTemplate(TemplateArgs args)
-        => args.TId.Equals(args.KnownTypes.String, SymbolEqualityComparer.Default) ?
+        => args.TValue.Equals(args.KnownTypes.String, SymbolEqualityComparer.Default) ?
             (stringSyntax ??= CodeTemplate.Parse(stringTemplate, args.KnownTypes.Compilation.GetParseOptions())) :
             (typedSyntax ??= CodeTemplate.Parse(typeTemplate, args.KnownTypes.Compilation.GetParseOptions()));
 

--- a/src/StructId.Analyzer/DapperExtensions.sbn
+++ b/src/StructId.Analyzer/DapperExtensions.sbn
@@ -43,10 +43,10 @@ public static partial class DapperExtensions
         return connection;
     }
 
-    partial class DapperTypeHandler<TSelf, TId, THandler> : TypeHandler<TSelf>
-        where TSelf : IStructId<TId>, INewable<TSelf, TId>
-        where THandler : TypeHandler<TId>, new()
-        where TId : struct
+    partial class DapperTypeHandler<TSelf, TValue, THandler> : TypeHandler<TSelf>
+        where TSelf : IStructId<TValue>, INewable<TSelf, TValue>
+        where THandler : TypeHandler<TValue>, new()
+        where TValue : struct
     {
         readonly THandler handler = new();
 

--- a/src/StructId.Analyzer/EntityFrameworkSelector.sbn
+++ b/src/StructId.Analyzer/EntityFrameworkSelector.sbn
@@ -43,7 +43,7 @@ public static class StructIdDbContextOptionsBuilderExtensions
             {{~ for id in Ids ~}}
             if (modelClrType == typeof({{ id.TSelf }}))
                 yield return converters.GetOrAdd((modelClrType, providerClrType), key => new ValueConverterInfo(
-                    key.ModelClrType, key.ProviderClrType ?? typeof({{ id.TId }}),
+                    key.ModelClrType, key.ProviderClrType ?? typeof({{ id.TValue }}),
                     info => new {{ id.TSelf }}.EntityFrameworkValueConverter(info.MappingHints)));
 
             {{~ end ~}}

--- a/src/StructId.Analyzer/RecordAnalyzer.cs
+++ b/src/StructId.Analyzer/RecordAnalyzer.cs
@@ -62,7 +62,7 @@ public class RecordAnalyzer : DiagnosticAnalyzer
             return;
 
         // If there are parameters, it must be only one, be named Value and be either 
-        // type string (if implementing IStructId) or the TId (if implementing IStructId<TId>)
+        // type string (if implementing IStructId) or the TValue (if implementing IStructId<TValue>)
         if (typeDeclaration.ParameterList.Parameters.Count != 1)
         {
             context.ReportDiagnostic(Diagnostic.Create(MustHaveValueConstructor, typeDeclaration.ParameterList.GetLocation(), symbol.Name));

--- a/src/StructId.Analyzer/TValueTemplateExtensions.cs
+++ b/src/StructId.Analyzer/TValueTemplateExtensions.cs
@@ -53,14 +53,14 @@ record TValueTemplateInfo(INamedTypeSymbol TTemplate, KnownTypes KnownTypes)
             return true;
 
         // If the template had a generic attribute, we'd be looking at an intermediate 
-        // type (typically TValue or TId) being used to define multiple constraints on 
+        // type (typically TValue) being used to define multiple constraints on 
         // the struct id's value type, such as implementing multiple interfaces. In 
-        // this case, the tid would never equal or inherit from the template's TId, 
+        // this case, the tid would never equal or inherit from the template's TValue, 
         // but we want instead to check for base type compatibility plus all interfaces.
         return TValue.IsFileLocal &&
-             // TId is a derived class of the template's TId base type (i.e. object or ValueType)
+             // TValue is a derived class of the template's TValue base type (i.e. object or ValueType)
              valueType.Is(TValue.BaseType) &&
-             // All template provided TId interfaces must be implemented by the struct id's TId
+             // All template provided TValue interfaces must be implemented by the struct id's TValue
              TValue.AllInterfaces.All(iface =>
                 valueType.AllInterfaces.Any(tface => tface.Is(iface)));
     }
@@ -99,7 +99,7 @@ static class TValueTemplateExtensions
             .SelectMany((x, _) =>
             {
                 var ((id, known), templates) = x;
-                // Locate the IStructId<TId> interface implemented by the id
+                // Locate the IStructId<TValue> interface implemented by the id
                 var structId = id.AllInterfaces.First(i => i.Is(known.IStructIdT));
                 var tvalue = (INamedTypeSymbol)structId.TypeArguments[0];
                 return templates
@@ -113,9 +113,9 @@ static class TValueTemplateExtensions
     //void GenerateCode(SourceProductionContext context, TIdTemplate source)
     //{
     //    var templateFile = Path.GetFileNameWithoutExtension(source.Template.Syntax.SyntaxTree.FilePath);
-    //    var hintName = $"{source.TId.ToFileName()}/{templateFile}.cs";
+    //    var hintName = $"{source.TValue.ToFileName()}/{templateFile}.cs";
 
-    //    var applied = source.Template.Syntax.Apply(source.TId);
+    //    var applied = source.Template.Syntax.Apply(source.TValue);
     //    var output = applied.ToFullString();
 
     //    context.AddSource(hintName, SourceText.From(output, Encoding.UTF8));

--- a/src/StructId.Tests/CodeTemplateTests.cs
+++ b/src/StructId.Tests/CodeTemplateTests.cs
@@ -35,7 +35,7 @@ public class CodeTemplateTests(ITestOutputHelper output)
                 // from template
             }
 
-            file record struct TId;
+            file record struct TValue;
             """;
 
         var id = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(

--- a/src/StructId.Tests/TemplateGeneratorTests.cs
+++ b/src/StructId.Tests/TemplateGeneratorTests.cs
@@ -42,14 +42,14 @@ public class TemplateGeneratorTests
                     using StructId;
 
                     [TStructId]
-                    file partial record struct TSelf(TId Value) : IComparable<TSelf>
+                    file partial record struct TSelf(TValue Value) : IComparable<TSelf>
                     {
                         public int CompareTo(TSelf other) => Value.CompareTo(other.Value);
                     }
 
-                    file record struct TId : IComparable<TId>
+                    file record struct TValue : IComparable<TValue>
                     {
-                        public int CompareTo(TId other) => throw new NotImplementedException();
+                        public int CompareTo(TValue other) => throw new NotImplementedException();
                     }
                     """
                 },
@@ -107,15 +107,15 @@ public class TemplateGeneratorTests
                     using StructId;
 
                     [TStructId]
-                    file partial record struct TSelf(TId Value) : IComparable<TSelf>
+                    file partial record struct TSelf(TValue Value) : IComparable<TSelf>
                     {
-                        // By casting to IComparable<TId> we can support explicit interface implementation too
-                        public int CompareTo(TSelf other) => ((IComparable<TId>)Value).CompareTo(other.Value);
+                        // By casting to IComparable<TValue> we can support explicit interface implementation too
+                        public int CompareTo(TSelf other) => ((IComparable<TValue>)Value).CompareTo(other.Value);
                     }
 
-                    file record struct TId : IComparable<TId>
+                    file record struct TValue : IComparable<TValue>
                     {
-                        public int CompareTo(TId other) => throw new NotImplementedException();
+                        public int CompareTo(TValue other) => throw new NotImplementedException();
                     }
                     """
                 },

--- a/src/StructId/INewableT.cs
+++ b/src/StructId/INewableT.cs
@@ -6,10 +6,10 @@ namespace StructId;
 /// Interface implemented by <see cref="IStructId{T}"/> 
 /// that support creating new instances of the identifier.
 /// </summary>
-public interface INewable<TSelf, TId>
+public interface INewable<TSelf, TValue>
 {
     /// <summary>
     /// Creates a new identifier from the given identifier value.
     /// </summary>
-    public abstract static TSelf New(TId value);
+    public abstract static TSelf New(TValue value);
 }

--- a/src/StructId/IStructIdT.cs
+++ b/src/StructId/IStructIdT.cs
@@ -5,11 +5,11 @@ namespace StructId;
 /// <summary>
 /// Interface for struct-based identifiers.
 /// </summary>
-/// <typeparam name="TId">The struct type for the inner <see cref="Value"/> of the identifier.</typeparam>
-public partial interface IStructId<TId> where TId : struct
+/// <typeparam name="TValue">The struct type for the inner <see cref="Value"/> of the identifier.</typeparam>
+public partial interface IStructId<TValue> where TValue : struct
 {
     /// <summary>
     /// Gets the underlying value of the identifier.
     /// </summary>
-    TId Value { get; }
+    TValue Value { get; }
 }

--- a/src/StructId/ResourceTemplates/ConstructorT.cs
+++ b/src/StructId/ResourceTemplates/ConstructorT.cs
@@ -1,6 +1,6 @@
 ﻿using StructId;
 
 [TStructId]
-file readonly partial record struct TSelf(/*🙏*/ TId Value);
+file readonly partial record struct TSelf(/*🙏*/ TValue Value);
 
-file record struct TId;
+file record struct TValue;

--- a/src/StructId/ResourceTemplates/JsonConverterT.cs
+++ b/src/StructId/ResourceTemplates/JsonConverterT.cs
@@ -7,20 +7,20 @@ using System.Text.Json.Serialization;
 using StructId;
 
 [TStructId]
-[JsonConverter(typeof(StructIdConverters.SystemTextJsonConverter<TSelf, TId>))]
+[JsonConverter(typeof(StructIdConverters.SystemTextJsonConverter<TSelf, TValue>))]
 file partial record struct TSelf
 {
 }
 
-file partial record struct TSelf : IStructId<TId>, INewable<TSelf, TId>
+file partial record struct TSelf : IStructId<TValue>, INewable<TSelf, TValue>
 {
-    public TId Value => throw new NotImplementedException();
+    public TValue Value => throw new NotImplementedException();
 
-    public static TSelf New(TId value) => throw new NotImplementedException();
+    public static TSelf New(TValue value) => throw new NotImplementedException();
 }
 
-file record struct TId : IParsable<TId>
+file record struct TValue : IParsable<TValue>
 {
-    public static TId Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
-    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TId result) => throw new NotImplementedException();
+    public static TValue Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TValue result) => throw new NotImplementedException();
 }

--- a/src/StructId/ResourceTemplates/NewtonsoftJsonConverterT.cs
+++ b/src/StructId/ResourceTemplates/NewtonsoftJsonConverterT.cs
@@ -7,21 +7,21 @@ using Newtonsoft.Json;
 using StructId;
 
 [TStructId]
-[JsonConverter(typeof(StructIdConverters.NewtonsoftJsonConverter<TSelf, TId>))]
+[JsonConverter(typeof(StructIdConverters.NewtonsoftJsonConverter<TSelf, TValue>))]
 file readonly partial record struct TSelf
 {
 }
 
-file partial record struct TSelf : IStructId<TId>, INewable<TSelf, TId>, IParsable<TSelf>
+file partial record struct TSelf : IStructId<TValue>, INewable<TSelf, TValue>, IParsable<TSelf>
 {
-    public TId Value => throw new NotImplementedException();
-    public static TSelf New(TId value) => throw new NotImplementedException();
+    public TValue Value => throw new NotImplementedException();
+    public static TSelf New(TValue value) => throw new NotImplementedException();
     public static TSelf Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
     public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TSelf result) => throw new NotImplementedException();
 }
 
-file record struct TId : IParsable<TId>
+file record struct TValue : IParsable<TValue>
 {
-    public static TId Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
-    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TId result) => throw new NotImplementedException();
+    public static TValue Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TValue result) => throw new NotImplementedException();
 }

--- a/src/StructId/ResourceTemplates/NewtonsoftJsonConverter`1.cs
+++ b/src/StructId/ResourceTemplates/NewtonsoftJsonConverter`1.cs
@@ -8,16 +8,16 @@ namespace StructId;
 
 public static partial class StructIdConverters
 {
-    public class NewtonsoftJsonConverter<TSelf, TId> : JsonConverter<TSelf>
-        where TSelf : IStructId<TId>, IParsable<TSelf>, INewable<TSelf, TId>
-        where TId : struct
+    public class NewtonsoftJsonConverter<TSelf, TValue> : JsonConverter<TSelf>
+        where TSelf : IStructId<TValue>, IParsable<TSelf>, INewable<TSelf, TValue>
+        where TValue : struct
     {
         public override void WriteJson(JsonWriter writer, TSelf? id, JsonSerializer serializer) 
             => serializer.Serialize(writer, id == null ? null : id.Value);
 
         public override TSelf? ReadJson(JsonReader reader, Type objectType, TSelf? existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            var result = serializer.Deserialize<TId?>(reader);
+            var result = serializer.Deserialize<TValue?>(reader);
             return result.HasValue ? TSelf.New(result.Value) : default;
         }
     }

--- a/src/StructId/StructIdConverters.JsonConverter.cs
+++ b/src/StructId/StructIdConverters.JsonConverter.cs
@@ -9,12 +9,12 @@ namespace StructId;
 
 public static partial class StructIdConverters
 {
-    public class SystemTextJsonConverter<TSelf, TId> : JsonConverter<TSelf>
-        where TSelf : IStructId<TId>, INewable<TSelf, TId>
-        where TId: struct, IParsable<TId>
+    public class SystemTextJsonConverter<TSelf, TValue> : JsonConverter<TSelf>
+        where TSelf : IStructId<TValue>, INewable<TSelf, TValue>
+        where TValue: struct, IParsable<TValue>
     {
         public override TSelf Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-            => TSelf.New(TId.Parse(reader.GetString() ?? throw new FormatException("Unsupported null value for struct id."), CultureInfo.InvariantCulture));
+            => TSelf.New(TValue.Parse(reader.GetString() ?? throw new FormatException("Unsupported null value for struct id."), CultureInfo.InvariantCulture));
 
         public override void Write(Utf8JsonWriter writer, TSelf value, JsonSerializerOptions options)
         {
@@ -23,7 +23,7 @@ public static partial class StructIdConverters
                 case Guid guid:
                     writer.WriteStringValue(guid);
                     break;
-                case TId inner:
+                case TValue inner:
                     writer.WriteRawValue(inner.ToString());
                     break;
                 default:
@@ -32,7 +32,7 @@ public static partial class StructIdConverters
         }
 
         public override TSelf ReadAsPropertyName(ref global::System.Text.Json.Utf8JsonReader reader, global::System.Type typeToConvert, global::System.Text.Json.JsonSerializerOptions options)
-            => TSelf.New(TId.Parse(reader.GetString() ?? throw new FormatException("Unsupported null value for struct id."), CultureInfo.InvariantCulture));
+            => TSelf.New(TValue.Parse(reader.GetString() ?? throw new FormatException("Unsupported null value for struct id."), CultureInfo.InvariantCulture));
 
         public override void WriteAsPropertyName(global::System.Text.Json.Utf8JsonWriter writer, TSelf value, global::System.Text.Json.JsonSerializerOptions options)
             => writer.WritePropertyName(value.Value.ToString());

--- a/src/StructId/Templates/Comparable.cs
+++ b/src/StructId/Templates/Comparable.cs
@@ -5,10 +5,10 @@ using System;
 using StructId;
 
 [TStructId]
-file partial record struct TSelf(TId Value) : IComparable<TSelf>
+file partial record struct TSelf(TValue Value) : IComparable<TSelf>
 {
     /// <inheritdoc/>
-    public int CompareTo(TSelf other) => ((IComparable<TId>)Value).CompareTo(other.Value);
+    public int CompareTo(TSelf other) => ((IComparable<TValue>)Value).CompareTo(other.Value);
 
     /// <inheritdoc/>
     public static bool operator <(TSelf left, TSelf right) => left.Value.CompareTo(right.Value) < 0;
@@ -23,7 +23,7 @@ file partial record struct TSelf(TId Value) : IComparable<TSelf>
     public static bool operator >=(TSelf left, TSelf right) => left.Value.CompareTo(right.Value) >= 0;
 }
 
-file record struct TId : IComparable<TId>
+file record struct TValue : IComparable<TValue>
 {
-    public int CompareTo(TId other) => throw new NotImplementedException();
+    public int CompareTo(TValue other) => throw new NotImplementedException();
 }

--- a/src/StructId/Templates/ConversionT.cs
+++ b/src/StructId/Templates/ConversionT.cs
@@ -3,10 +3,10 @@
 using StructId;
 
 [TStructId]
-file partial record struct TSelf(TId Value)
+file partial record struct TSelf(TValue Value)
 {
-    public static implicit operator TId(TSelf id) => id.Value;
-    public static explicit operator TSelf(TId value) => new(value);
+    public static implicit operator TValue(TSelf id) => id.Value;
+    public static explicit operator TSelf(TValue value) => new(value);
 }
 
-file record struct TId;
+file record struct TValue;

--- a/src/StructId/Templates/NewableT.cs
+++ b/src/StructId/Templates/NewableT.cs
@@ -3,10 +3,10 @@
 using StructId;
 
 [TStructId]
-file partial record struct TSelf(TId Value) : INewable<TSelf, TId>
+file partial record struct TSelf(TValue Value) : INewable<TSelf, TValue>
 {
     /// <inheritdoc/>
-    public static TSelf New(TId value) => new(value);
+    public static TSelf New(TValue value) => new(value);
 }
 
-file record struct TId;
+file record struct TValue;

--- a/src/StructId/Templates/ParsableT.cs
+++ b/src/StructId/Templates/ParsableT.cs
@@ -6,15 +6,15 @@ using System;
 using StructId;
 
 [TStructId]
-file readonly partial record struct TSelf(/*!string*/ TId Value) : IParsable<TSelf>
+file readonly partial record struct TSelf(/*!string*/ TValue Value) : IParsable<TSelf>
 {
     /// <inheritdoc cref="IParsable{TSelf}"/>
-    public static TSelf Parse(string s, IFormatProvider? provider) => new(TId.Parse(s, provider));
+    public static TSelf Parse(string s, IFormatProvider? provider) => new(TValue.Parse(s, provider));
 
     /// <inheritdoc cref="IParsable{TSelf}"/>
     public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TSelf result)
     {
-        if (TId.TryParse(s, provider, out var value))
+        if (TValue.TryParse(s, provider, out var value))
         {
             result = new TSelf(value);
             return true;
@@ -24,8 +24,8 @@ file readonly partial record struct TSelf(/*!string*/ TId Value) : IParsable<TSe
     }
 }
 
-file record struct TId : IParsable<TId>
+file record struct TValue : IParsable<TValue>
 {
-    public static TId Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
-    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TId result) => throw new NotImplementedException();
+    public static TValue Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TValue result) => throw new NotImplementedException();
 }

--- a/src/StructId/Templates/SpanParsable.cs
+++ b/src/StructId/Templates/SpanParsable.cs
@@ -6,15 +6,15 @@ using System;
 using StructId;
 
 [TStructId]
-file readonly partial record struct TSelf(/*!string*/ TId Value) : ISpanParsable<TSelf>
+file readonly partial record struct TSelf(/*!string*/ TValue Value) : ISpanParsable<TSelf>
 {
     /// <inheritdoc cref="ISpanParsable{TSelf}"/>
-    public static TSelf Parse(ReadOnlySpan<char> input, IFormatProvider? provider) => new(TId.Parse(input, provider));
+    public static TSelf Parse(ReadOnlySpan<char> input, IFormatProvider? provider) => new(TValue.Parse(input, provider));
 
     /// <inheritdoc cref="ISpanParsable{TSelf}"/>
     public static bool TryParse(ReadOnlySpan<char> input, IFormatProvider? provider, out TSelf result)
     {
-        if (TId.TryParse(input, provider, out var value))
+        if (TValue.TryParse(input, provider, out var value))
         {
             result = new TSelf(value);
             return true;
@@ -30,10 +30,10 @@ file partial record struct TSelf
     public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TSelf result) => throw new NotImplementedException();
 }
 
-file record struct TId : ISpanParsable<TId>
+file record struct TValue : ISpanParsable<TValue>
 {
-    public static TId Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => throw new NotImplementedException();
-    public static TId Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
-    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, [MaybeNullWhen(false)] out TId result) => throw new NotImplementedException();
-    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TId result) => throw new NotImplementedException();
+    public static TValue Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => throw new NotImplementedException();
+    public static TValue Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, [MaybeNullWhen(false)] out TValue result) => throw new NotImplementedException();
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out TValue result) => throw new NotImplementedException();
 }


### PR DESCRIPTION
Since the property is called Value, it makes sense to refer to its type as TValue. This avoids confusion with the "id" being the struct id itself (and therefore the "id type" being unequivocally the struct id, rather than the type of value being wrapped).