### PR TITLE
Make feature-dependent templates conditional

### DIFF
--- a/src/StructId.Package/StructId.targets
+++ b/src/StructId.Package/StructId.targets
@@ -44,7 +44,23 @@
     <WriteRaw Content="%(StructId.Content)" SourcePath="%(StructId.FullPath)" TargetPath="%(StructId.TargetPath)" />
   </Target>
 
-  <Target Name="AddStructId" DependsOnTargets="IncludeStructIdAsIs;CopyStructIdNamespaced" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+  <Target Name="AddStructId" DependsOnTargets="IncludeStructIdAsIs;CopyStructIdNamespaced;ResolveLockFileReferences" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+    <!-- Feature detection -->
+    <PropertyGroup>
+      <UseDapper>false</UseDapper>
+      <UseDapper Condition="'@(Reference -> WithMetadataValue('NuGetPackageId', 'Dapper'))' != ''">true</UseDapper>
+      <UseEntityFramework>false</UseEntityFramework>
+      <UseEntityFramework Condition="'@(Reference -> WithMetadataValue('NuGetPackageId', 'Microsoft.EntityFrameworkCore'))' != ''">true</UseEntityFramework>
+      <UseUlid>false</UseUlid>
+      <UseUlid Condition="'@(Reference -> WithMetadataValue('NuGetPackageId', 'Ulid'))' != ''">true</UseUlid>
+    </PropertyGroup>
+    <ItemGroup>
+      <FeatureTemplatesToRemove Include="@(StructId -> WithMetadataValue('Filename', 'DapperTypeHandler'))" Condition="!$(UseDapper)" />
+      <FeatureTemplatesToRemove Include="@(StructId -> WithMetadataValue('Filename', 'EntityFrameworkValueConverter'))" Condition="!$(UseEntityFramework)" />
+      <FeatureTemplatesToRemove Include="@(StructId -> WithMetadataValue('Filename', 'NewableUlid'))" Condition="!$(UseUlid)" />
+      <StructId Remove="@(FeatureTemplatesToRemove)" />
+    </ItemGroup>
+    <!-- Add final template items to project -->
     <ItemGroup>
       <Compile Include="%(StructId.TargetPath)" />
     </ItemGroup>

--- a/src/StructId/Templates/NewableUlid.cs
+++ b/src/StructId/Templates/NewableUlid.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using StructId.Functional;
+using StructId;
 
 [TStructId]
 file partial record struct TSelf(Ulid Value)


### PR DESCRIPTION
As we moved to compiled templates for EF/Dapper/Ulid, we need to only include those templates in the compilation if the user actually references the respective packages.

For now, this is not an extensible mechanism nad we just detect the dependency on the relevant packages via MSBuild and remove the templates as needed.

We moved the Ulid support for New() (mirroring the support we offer for TId.New() for Guids) since it can now be conditional too.