### PR TITLE
Drastically simply packing and namespace management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,9 +41,6 @@ The package is a [development dependency](https://github.com/NuGet/Home/wiki/Dev
 meaning it will not add any run-time dependencies to your project (or package if you 
 publish one that uses struct ids).
 
-The default target namespace for the included types will match the `RootNamespace` of the 
-project, but can be customized by setting the `StructIdNamespace` property.
-
 You can simply declare a new ID type by implementing `IStructId<TValue>`:
 
 ```csharp

--- a/src/StructId.Analyzer/CodeTemplate.cs
+++ b/src/StructId.Analyzer/CodeTemplate.cs
@@ -53,6 +53,9 @@ public static class CodeTemplate
 
         var tid = iface.TypeArguments.FirstOrDefault()?.ToFullName() ?? "string";
         var corens = iface.ContainingNamespace.ToFullName();
+        if (string.IsNullOrEmpty(corens))
+            corens = nameof(StructId);
+
         var targetNamespace = structId.ContainingNamespace != null && !structId.ContainingNamespace.IsGlobalNamespace ?
             structId.ContainingNamespace.ToDisplayString() : null;
 

--- a/src/StructId.Analyzer/KnownTypes.cs
+++ b/src/StructId.Analyzer/KnownTypes.cs
@@ -20,13 +20,13 @@ public record KnownTypes(Compilation Compilation)
     /// StructId.IStructId
     /// </summary>
     public INamedTypeSymbol? IStructId { get; } = Compilation
-        .GetAllTypes(true)
+        .GetAllTypes(includeReferenced: true)
         .FirstOrDefault(x => x.MetadataName == "IStructId" && x.IsGeneratedByStructId());
 
     /// <summary>
     /// StructId.IStructId{T}
     /// </summary>
     public INamedTypeSymbol? IStructIdT { get; } = Compilation
-        .GetAllTypes(true)
+        .GetAllTypes(includeReferenced: true)
         .FirstOrDefault(x => x.MetadataName == "IStructId`1" && x.IsGeneratedByStructId());
 }

--- a/src/StructId.FunctionalTests/NoNs.cs
+++ b/src/StructId.FunctionalTests/NoNs.cs
@@ -1,4 +1,5 @@
-﻿using StructId.Functional;
+﻿using StructId;
+using StructId.Functional;
 
 // Showcases that types don't need to have a namespace
 public partial record struct NoNsId : IStructId;

--- a/src/StructId.FunctionalTests/StructId.FunctionalTests.csproj
+++ b/src/StructId.FunctionalTests/StructId.FunctionalTests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\StructId.Package\StructId.props" />
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/StructId.FunctionalTests/UlidEntityFramework.cs
+++ b/src/StructId.FunctionalTests/UlidEntityFramework.cs
@@ -2,7 +2,7 @@
 #nullable enable
 
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StructId.Functional;
+using StructId;
 
 [TStructId]
 file partial record struct TSelf(Ulid Value) : INewable<TSelf, Ulid>

--- a/src/StructId.Package/StructId.Package.msbuildproj
+++ b/src/StructId.Package/StructId.Package.msbuildproj
@@ -5,7 +5,8 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <Description>Stronly typed ids using readonly record structs and modern C# features.</Description>
     <PackageTags>dotnet record struct typed id</PackageTags>
-    <PackFolder>build</PackFolder>
+    <PackFolder>buildTransitive</PackFolder>
+    <PackNone>true</PackNone>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NuGetizer" Version="1.2.3" />
@@ -15,7 +16,7 @@
     <ProjectReference Include="..\StructId.CodeFix\StructId.CodeFix.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\StructId\*.cs" Visible="false" />
+    <Content Include="..\StructId\*.cs" BuildAction="Compile" CodeLanguage="cs" Pack="true" />
     <None Include="..\StructId\Templates\*.cs" PackFolder="$(PackFolder)\Templates" Visible="false" />
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/StructId.Package/StructId.props
+++ b/src/StructId.Package/StructId.props
@@ -1,3 +1,0 @@
-<Project>
-
-</Project>

--- a/src/StructId.Package/StructId.targets
+++ b/src/StructId.Package/StructId.targets
@@ -1,50 +1,21 @@
 <Project>
 
-  <PropertyGroup>
-    <StructIdNamespace Condition="$(StructIdNamespace) == ''">$(RootNamespace)</StructIdNamespace>
-    <StructIdNamespace Condition="$(StructIdNamespace) == ''">StructId</StructIdNamespace>
-    <StructIdPathHash Condition="$(StructIdNamespace) != ''">$([MSBuild]::StableStringHash($(StructIdNamespace)))\</StructIdPathHash>
-  </PropertyGroup>
-
   <ItemGroup>
-    <StructId Include="$(MSBuildThisFileDirectory)*.cs" Link="StructId\$(StructIdPathHash)%(Filename)%(Extension)" />
-    <StructId Include="$(MSBuildThisFileDirectory)Templates\*.cs" Link="StructId\$(StructIdPathHash)Templates\%(Filename)%(Extension)" />
+    <!-- This is safe to do even if we're in a transitive targets file, since content files providing 
+         these items won't exist in a transitive project. See https://github.com/NuGet/Home/issues/7420 -->
+    <Compile Update="@(Compile)">
+      <Visible Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'StructId'">false</Visible>
+      <Link Condition="'%(NuGetItemType)' == 'Compile' and '%(NuGetPackageId)' == 'StructId'">StructId\%(Filename)%(Extension)</Link>
+    </Compile>
+
+    <!-- Templates should always be added transitively since they are all file-local and their 
+         syntax tree is required in the compilation for them to apply properly -->
+    <StructId Include="$(MSBuildThisFileDirectory)Templates\*.cs"
+              Link="StructId\Templates\%(Filename)%(Extension)"
+              Visible="false"/>    
   </ItemGroup>
 
-  <Target Name="CollectStructIds">
-    <ItemGroup>
-      <StructId>
-        <TargetPath>$(IntermediateOutputPath)%(Link)</TargetPath>
-      </StructId>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="IncludeStructIdAsIs" Condition="$(StructIdNamespace) == 'StructId'" DependsOnTargets="CollectStructIds" Inputs="@(StructId)" Outputs="%(StructId.TargetPath)">
-    <!-- No copying needed in this case, we'll just include the original files. -->
-    <ItemGroup>
-      <StructId>
-        <TargetPath>%(FullPath)</TargetPath>
-      </StructId>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="AddStructIdContent" Condition="$(StructIdNamespace) != 'StructId'" DependsOnTargets="CollectStructIds" Inputs="@(StructId)" Outputs="|%(StructId.Identity)|">
-    <PropertyGroup>
-      <StructIdContent>$([System.IO.File]::ReadAllText(%(StructId.FullPath)))</StructIdContent>
-      <StructIdContent>$(StructIdContent.Replace('using StructId', 'using $(StructIdNamespace)').Replace('namespace StructId', 'namespace $(StructIdNamespace)'))</StructIdContent>
-    </PropertyGroup>
-    <ItemGroup>
-      <StructId>
-        <Content>$([MSBuild]::Unescape($(StructIdContent)))</Content>
-      </StructId>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CopyStructIdNamespaced" Condition="$(StructIdNamespace) != 'StructId'" DependsOnTargets="AddStructIdContent" Inputs="@(StructId)" Outputs="%(StructId.TargetPath)">
-    <WriteRaw Content="%(StructId.Content)" SourcePath="%(StructId.FullPath)" TargetPath="%(StructId.TargetPath)" />
-  </Target>
-
-  <Target Name="AddStructId" DependsOnTargets="IncludeStructIdAsIs;CopyStructIdNamespaced;ResolveLockFileReferences" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
+  <Target Name="AddStructId" DependsOnTargets="ResolveLockFileReferences" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <!-- Feature detection -->
     <PropertyGroup>
       <UseDapper>false</UseDapper>
@@ -62,29 +33,8 @@
     </ItemGroup>
     <!-- Add final template items to project -->
     <ItemGroup>
-      <Compile Include="%(StructId.TargetPath)" />
+      <Compile Include="%(StructId.FullPath)" />
     </ItemGroup>
   </Target>
-
-  <UsingTask TaskName="WriteRaw" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <Content ParameterType="System.String" Required="true" />
-      <SourcePath ParameterType="System.String" Required="true" />
-      <TargetPath ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text"/>
-      <Using Namespace="Microsoft.Build.Framework"/>
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-        Directory.CreateDirectory(Path.GetDirectoryName(TargetPath));
-        File.WriteAllText(TargetPath, Content, Encoding.UTF8);
-        File.SetLastWriteTimeUtc(TargetPath, File.GetLastWriteTimeUtc(SourcePath));
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
 
 </Project>

--- a/src/StructId.Tests/StructId.Tests.csproj
+++ b/src/StructId.Tests/StructId.Tests.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\StructId.Package\StructId.props" />
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
The ability to customize the namespace of the struct id types seemed a bit of a corner case and it was introducing non-trivial complexity in scenarios involving transitive project references (analyzers are transitive, as well as buildTransitive targets, but analyzer options, contentFiles -with or without compile action- are not). This was leading to hack over hack for no serious gain.

So even if we keep the CodeTemplate behavior intact should we figure out how to properly handle changing the namespace, this change removes the copying and content updating on the static files, which are now simply included via nuget's contentFiles feature plus buildAction=Compile. This provides the behavior we're looking for:

- Interfaces and types required for struct ids are only added to the project referencing the package
- using and codegen for struct ids is supported in projects referencing the "core" one: analyzers are already transitive, we just make the templates transitive too via targets (since we can't via contentFiles).