### PR TITLE
Allow running samples from main solution for debugging

### DIFF
--- a/src/Sample/Common/Product.cs
+++ b/src/Sample/Common/Product.cs
@@ -1,4 +1,6 @@
-﻿namespace Sample;
+﻿using StructId;
+
+namespace Sample;
 
 public record Product(ProductId Id, string Name);
 

--- a/src/Sample/ConsoleDb/Program.cs
+++ b/src/Sample/ConsoleDb/Program.cs
@@ -1,6 +1,6 @@
-﻿using ConsoleDb;
-using Dapper;
+﻿using Dapper;
 using Microsoft.Data.Sqlite;
+using StructId;
 
 SQLitePCL.Batteries.Init();
 

--- a/src/Sample/Directory.Build.props
+++ b/src/Sample/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <FromSource>false</FromSource>
+    <FromSource Condition="$(SolutionName) == 'StructId'">true</FromSource>
+  </PropertyGroup>
+
+</Project>

--- a/src/Sample/Directory.Build.targets
+++ b/src/Sample/Directory.Build.targets
@@ -1,0 +1,36 @@
+<Project>
+  <Import Project="..\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)..\StructId.Package\StructId.targets</AfterMicrosoftNETSdkTargets>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(FromSource)">
+    <PackageReference Remove="StructId" />
+    <PackageReference Include="Scriban" Version="5.12.1" GeneratePathProperty="true" />
+
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\StructId.Analyzer\StructId.Analyzer.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\StructId.CodeFix\StructId.CodeFix.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\StructId.Package\StructId.Package.msbuildproj" ReferenceOutputAssembly="false" />
+
+    <Analyzer Include="$(PkgScriban)/lib/netstandard2.0/Scriban.dll" Condition="Exists('$(PkgScriban)/lib/netstandard2.0/Scriban.dll')" />
+  </ItemGroup>
+
+  <Target Name="FromSource" Condition="$(FromSource)" BeforeTargets="AddStructId">
+    <ItemGroup>
+      <!-- These would be added from the package-relative paths by the StructId.targets -->
+      <StructIdCompile Include="$(MSBuildThisFileDirectory)..\StructId\*.cs" />
+      <StructIdTemplates Include="$(MSBuildThisFileDirectory)..\StructId\Templates\*.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Templates should always be added by buildTransitive targets -->
+      <StructId Include="@(StructIdTemplates)" Link="StructId\Templates\%(StructIdTemplates.Filename)%(StructIdTemplates.Extension)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(HasStructIdReference)' != 'false'">
+      <StructId Include="@(StructIdCompile)" Link="StructId\%(StructIdCompile.Filename)%(StructIdCompile.Extension)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Sample/MinimalApi/MinimalApi.csproj
+++ b/src/Sample/MinimalApi/MinimalApi.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RestoreSources>https://api.nuget.org/v3/index.json;$(PackageOutputPath)</RestoreSources>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <HasStructIdReference>false</HasStructIdReference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sample/MinimalApi/Program.cs
+++ b/src/Sample/MinimalApi/Program.cs
@@ -1,4 +1,5 @@
 using Sample;
+using StructId;
 
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
@@ -8,6 +9,6 @@ app.MapGet("/product/{id}", (ProductId id) => new Product(id, Ipsum.GetPhrase(5)
 
 app.Run();
 
-readonly partial record struct UserId : IStructId<int>;
+readonly partial record struct UserId(int Value) : IStructId<int>;
 
 record User(UserId id, string Alias);

--- a/src/Sample/MvcWebApp/Controllers/HomeController.cs
+++ b/src/Sample/MvcWebApp/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Sample;
+using StructId;
 
 namespace MvcWebApplication.Controllers;
 
@@ -24,6 +25,6 @@ public class HomeController : Controller
     }
 }
 
-public readonly partial record struct UserId : IStructId<Guid>;
+public readonly partial record struct UserId : IStructId<Ulid>;
 
 public record User(UserId id, string Alias);

--- a/src/Sample/MvcWebApp/MvcWebApp.csproj
+++ b/src/Sample/MvcWebApp/MvcWebApp.csproj
@@ -6,7 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RestoreSources>https://api.nuget.org/v3/index.json;$(PackageOutputPath)</RestoreSources>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <HasStructIdReference>false</HasStructIdReference>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Ulid" Version="1.3.4" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />

--- a/src/StructId.Analyzer/Properties/launchSettings.json
+++ b/src/StructId.Analyzer/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "Roslyn": {
       "commandName": "DebugRoslynComponent",
       "targetProject": "..\\StructId.FunctionalTests\\StructId.FunctionalTests.csproj"
+    },
+    "MinimalApi": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\Sample\\MinimalApi\\MinimalApi.csproj"
     }
   }
 }


### PR DESCRIPTION
Projects can be added to the main solution and set as the target for roslyn debugging as needed.

The new directory targets simulate package referencing and remove the actual package reference that's otherwise used (using solution name to detect standalone vs debugging sources mode).