### PR TITLE
Annotate compiled templates with NuGetPackageId metadata

### DIFF
--- a/src/StructId.Package/StructId.targets
+++ b/src/StructId.Package/StructId.targets
@@ -33,7 +33,7 @@
     </ItemGroup>
     <!-- Add final template items to project -->
     <ItemGroup>
-      <Compile Include="%(StructId.FullPath)" />
+      <Compile Include="%(StructId.FullPath)" NuGetPackageId="StructId" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
For consistency with nuget-provided compile items.