### PR TITLE
Trim package dependencies significantly

### DIFF
--- a/src/StructId.Analyzer/StructId.Analyzer.csproj
+++ b/src/StructId.Analyzer/StructId.Analyzer.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" Version="4.8.0" />
     <PackageReference Include="NuGetizer" Version="1.4.7" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
-    <PackageReference Include="Scriban" Version="7.1.0" IncludeAssets="Build" />
+    <PackageReference Include="Scriban" Version="7.1.0" IncludeAssets="Build" Pack="false" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.0.10" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="2.0.10" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Resources" Version="2.0.10" PrivateAssets="all" />

--- a/src/StructId/StructId.csproj
+++ b/src/StructId/StructId.csproj
@@ -5,11 +5,16 @@
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="!$(CI)">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Ulid" Version="1.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(CI)'">
+    <Compile Remove="ResourceTemplates\*.*" />
+    <Compile Remove="Templates\*.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We don't really need to compile nor depend on the template-used packages when we build in CI for production.

The reason we keep templates as source in the main library is that it ensures we locally detect any build breakages that may happen, but analyzer pulls in those as source.