### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,7 +49,11 @@ jobs:
           # if we don't have at least 100 requests left, wait until reset
           if ($rate.remaining -lt 100) {
               $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
-              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              if ($wait -gt 300) {
+                  echo "Rate limit remaining is $($rate.remaining), reset in $wait seconds (more than 5'). Aborting."
+                  exit 1
+              }
+              echo "Rate limit remaining is $($rate.remaining), waiting $wait seconds to reset"
               sleep $wait
               $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
               echo "Rate limit has reset to $($rate.remaining) requests"

--- a/.netconfig
+++ b/.netconfig
@@ -74,9 +74,9 @@
 	weak
 [file ".github/workflows/triage.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/triage.yml
-	sha = 33000c0c4ab4eb4e0e142fa54515b811a189d55c
+	sha = 61a602fc61eedbdae235f01e93657a6219ac2427
 
-	etag = 013a47739e348f06891f37c45164478cca149854e6cd5c5158e6f073f852b61a
+	etag = 152cd3a559c08da14d1da12a5262ba1d2e0ed6bed6d2eabf5bd209b0c35d8a75
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore


### PR DESCRIPTION
# devlooped/oss

- Cap rate limit wait at 5 minutes, abort if longer https://github.com/devlooped/oss/commit/61a602f