### PR TITLE
Update Guid-backed ID factory to use CreateVersion7 on .NET 9+

### DIFF
--- a/src/SKILL.md
+++ b/src/SKILL.md
@@ -100,13 +100,14 @@ For every struct ID, the source generator emits:
 - Implicit/explicit conversion operators to/from `TValue`
 - `INewable<TSelf>` / `INewable<TSelf, TValue>` implementation
 - `New(TValue value)` static factory method
-- `New()` (parameterless) for `Guid`- and `Ulid`-backed IDs, using `Guid.NewGuid()` / `Ulid.NewUlid()`
+- `New()` (parameterless) for `Guid`- and `Ulid`-backed IDs, using `Guid.CreateVersion7()` on .NET 9+ or `Guid.NewGuid()` on earlier targets / `Ulid.NewUlid()`
 
 ## Factory Methods
 
 ```csharp
 // Guid-backed: parameterless New() generates a new GUID
-var userId  = UserId.New();              // new UserId(Guid.NewGuid())
+// On .NET 9+, uses Guid.CreateVersion7(); earlier targets use Guid.NewGuid()
+var userId  = UserId.New();              // new UserId(Guid.CreateVersion7()) on .NET 9+
 var userId2 = UserId.New(someGuid);      // new UserId(someGuid)
 
 // Ulid-backed: parameterless New() generates a new ULID

--- a/src/StructId/Templates/NewableGuid.cs
+++ b/src/StructId/Templates/NewableGuid.cs
@@ -6,8 +6,13 @@ using StructId;
 [TStructId]
 file partial record struct TSelf(Guid Value)
 {
-    /// <summary>
-    /// Creates a new instance of <typeparamref name="TSelf"/> with a <see cref="Guid.NewGuid"/>.
-    /// </summary>
-    public static TSelf New() => new(Guid.NewGuid());
+    /// <summary>Creates a new instance with a newly generated <see cref="Guid"/>.</summary>
+    public static TSelf New()
+    {
+#if NET9_0_OR_GREATER
+        return new(Guid.CreateVersion7());
+#else
+        return new(Guid.NewGuid());
+#endif
+    }
 }


### PR DESCRIPTION
The source generator now emits New() for Guid-backed IDs that uses Guid.CreateVersion7() on .NET 9+ and falls back to Guid.NewGuid() on earlier versions. Updated docs and implementation in NewableGuid.cs to match this logic.