### PR TITLE
Improve CopyStructIdSkill MSBuild target

### DIFF
--- a/src/StructId.Package/StructId.targets
+++ b/src/StructId.Package/StructId.targets
@@ -19,11 +19,12 @@
     Copies SKILL.md from this package to .agents/skills/structid/ in the consuming repo root.
     Uses InitializeSourceControlInformation (SourceLink) to locate the repo root.
     Falls back to SolutionDir if the git root cannot be determined.
+    Falls back to the directory containing the nearest AGENTS.md file found above the project file.
     Silently skips if the base directory cannot be determined.
     Opt-out: set <StructIdSkill>false</StructIdSkill> in your project or Directory.Build.props.
   -->
   <Target Name="CopyStructIdSkill"
-          AfterTargets="Build"
+          BeforeTargets="PrepareForBuild"
           DependsOnTargets="InitializeSourceControlInformation"
           Condition="'$(StructIdSkill)' != 'false'">
 
@@ -34,7 +35,13 @@
     <PropertyGroup>
       <_StructIdSkillRepoRoot>@(_StructIdSkillSourceRoot)</_StructIdSkillRepoRoot>
       <_StructIdSkillRepoRoot Condition="'$(_StructIdSkillRepoRoot)' == '' and '$(SolutionDir)' != '' and '$(SolutionDir)' != '*Undefined*'">$(SolutionDir)</_StructIdSkillRepoRoot>
+      <_StructIdSkillAgentsMd Condition="'$(_StructIdSkillRepoRoot)' == ''">$([MSBuild]::GetPathOfFileAbove('AGENTS.md', '$(MSBuildProjectDirectory)'))</_StructIdSkillAgentsMd>
+      <_StructIdSkillRepoRoot Condition="'$(_StructIdSkillRepoRoot)' == '' and '$(_StructIdSkillAgentsMd)' != ''">$([System.IO.Path]::GetDirectoryName('$(_StructIdSkillAgentsMd)'))\</_StructIdSkillRepoRoot>
     </PropertyGroup>
+
+    <MakeDir Directories="$(_StructIdSkillRepoRoot).agents\skills\structid"
+             Condition="'$(_StructIdSkillRepoRoot)' != '' and Exists('$(MSBuildThisFileDirectory)..\skills\structid\SKILL.md')"
+             ContinueOnError="true" />
 
     <Copy SourceFiles="$(MSBuildThisFileDirectory)..\skills\structid\SKILL.md"
           DestinationFiles="$(_StructIdSkillRepoRoot).agents\skills\structid\SKILL.md"


### PR DESCRIPTION
Aligns the \CopyStructIdSkill\ target in \StructId.targets\ with the approach used in \Devlooped.Extensions.AI.targets\:

- **\BeforeTargets="PrepareForBuild"\** – the SKILL.md file is now copied before the build starts rather than after it completes
- **AGENTS.md fallback** – if neither SourceLink nor \SolutionDir\ resolves the repo root, the target now walks up from the project directory looking for an \AGENTS.md\ file and uses its containing directory
- **Explicit \MakeDir\** – the destination directory is created explicitly with \ContinueOnError="true"\ before the copy, instead of relying on \Copy\ to do it implicitly